### PR TITLE
Pale Moon 27.1+ support

### DIFF
--- a/browserspecific/firefox/package.json
+++ b/browserspecific/firefox/package.json
@@ -12,5 +12,9 @@
 	"permissions": {"private-browsing": true},
 	"preferences": [ {"title": "Preferences", "type": "control", "name": "myButtonPref", "label": "Customize Scroll To Top"} ],
 	"title": "Scroll To Top",
-	"version": "4.5.5"
+	"version": "4.5.5",
+	"engines": {
+		"firefox": ">=38.0a1",
+		"{8de7fcbb-c55c-4fbe-bfc5-fc555c87dbc4}": ">=27.1.0b1"
+	}
 }


### PR DESCRIPTION
Based on [PMkit documentation draft v1.1](https://github.com/JustOff/pm27-sdk-addons/blob/master/PMkit.md), tested with [Pale Moon 27.1.0b1](http://www.palemoon.org/unstable/).